### PR TITLE
Fix content script injection logic

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -71,5 +71,9 @@
     container.appendChild(btn);
   }
 
-  document.addEventListener('DOMContentLoaded', injectButton);
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', injectButton);
+  } else {
+    injectButton();
+  }
 })();


### PR DESCRIPTION
## Summary
- inject the Export Resume button immediately if the document has already loaded

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68402362bab8832a9d01af7fe2bd9163